### PR TITLE
Fix: Correct SQL queries and activator defaults for DB schema

### DIFF
--- a/includes/class-wzi-activator.php
+++ b/includes/class-wzi-activator.php
@@ -155,15 +155,37 @@ class WZI_Activator {
             $wpdb->insert(
                 $mapping_table,
                 array(
-                    'entity_type' => $mapping[0],
-                    'woo_field' => $mapping[1],
+                    'module' => $mapping[0],             // entity_type -> module
+                    'wc_field' => $mapping[1],           // woo_field -> wc_field
                     'zoho_field' => $mapping[2],
-                    'sync_direction' => $mapping[3],
+                    'direction' => $mapping[3],          // sync_direction -> direction
                     'transform_function' => $mapping[4],
+                    // Faltaban zoho_module y is_custom/is_active si se quieren poner valores no por defecto aquí
+                    // Asumiendo que zoho_module es el mismo que el módulo de Zoho destino (ej. Contacts para customer)
+                    // y que los mapeos por defecto son 'is_custom' = 0, 'is_active' = 1
+                    'zoho_module' => self::map_entity_to_default_zoho_module($mapping[0]), // Helper para obtener el módulo Zoho
+                    'is_custom' => 0,
+                    'is_active' => 1,
                 ),
-                array('%s', '%s', '%s', '%s', '%s')
+                array('%s', '%s', '%s', '%s', '%s', '%s', '%d', '%d') // Actualizar formatos
             );
         }
+    }
+
+    /**
+     * Mapear tipo de entidad de WC a módulo de Zoho por defecto.
+     * Helper para set_default_field_mappings.
+     *
+     * @param string $entity_type Tipo de entidad de WooCommerce (e.g., 'customer', 'order', 'product')
+     * @return string Nombre del módulo de Zoho correspondiente.
+     */
+    private static function map_entity_to_default_zoho_module($entity_type) {
+        $map = array(
+            'customer' => 'Contacts', // O 'Leads' según la configuración deseada
+            'order'    => 'Sales_Orders', // O 'Deals'
+            'product'  => 'Products', // O 'Items' si se usa más Zoho Inventory/Books para productos
+        );
+        return $map[$entity_type] ?? ucfirst($entity_type) . 's'; // Fallback simple
     }
     
     /**

--- a/includes/sync/class-wzi-sync-orders.php
+++ b/includes/sync/class-wzi-sync-orders.php
@@ -79,15 +79,16 @@ class WZI_Sync_Orders {
         $mapping_table = $wpdb->prefix . 'wzi_field_mapping';
         
         $mappings = $wpdb->get_results($wpdb->prepare(
-            "SELECT woo_field, zoho_field, sync_direction, transform_function FROM {$mapping_table} 
-             WHERE entity_type = %s AND is_active = 1",
+            "SELECT wc_field, zoho_field, direction, transform_function FROM {$mapping_table}
+             WHERE module = %s AND is_active = 1", // woo_field -> wc_field, sync_direction -> direction, entity_type -> module
             'order' 
         ));
         
         foreach ($mappings as $mapping) {
-            $this->field_mapping[$mapping->woo_field] = array(
+            // Al acceder a las propiedades del objeto $mapping, usar los nombres de columna corregidos
+            $this->field_mapping[$mapping->wc_field] = array(
                 'zoho_field' => $mapping->zoho_field,
-                'sync_direction' => $mapping->sync_direction,
+                'sync_direction' => $mapping->direction, // Corregido aquí también
                 'transform_function' => $mapping->transform_function,
             );
         }


### PR DESCRIPTION
- Corrected column names in SQL queries for 'wp_wzi_field_mapping' in class-wzi-sync-orders.php (woo_field->wc_field, entity_type->module, sync_direction->direction).
- Corrected column names in SQL queries for 'wp_wzi_sync_logs' in class-wzi-sync-manager.php (sync_type->source, created_at->timestamp). Adjusted stats query due to missing columns (sync_direction, status).
- Updated WZI_Activator::set_default_field_mappings to use correct column names and include all necessary columns (module, wc_field, direction, zoho_module, is_custom, is_active).
- Added helper WZI_Activator::map_entity_to_default_zoho_module.