### PR TITLE
Fix: Correct field mapping loads and textdomain hook

### DIFF
--- a/includes/class-wzi-main.php
+++ b/includes/class-wzi-main.php
@@ -162,7 +162,9 @@ class WZI_Main {
      */
     private function set_locale() {
         $plugin_i18n = new WZI_i18n();
-        $this->loader->add_action('plugins_loaded', $plugin_i18n, 'load_plugin_textdomain');
+        // Cambiar el hook de 'plugins_loaded' a 'init' para la carga del textdomain.
+        // El textdomain se define en la cabecera del plugin, WZI_i18n debería usar ese.
+        $this->loader->add_action('init', $plugin_i18n, 'load_plugin_textdomain');
     }
 
     /**

--- a/includes/sync/class-wzi-sync-customers.php
+++ b/includes/sync/class-wzi-sync-customers.php
@@ -91,15 +91,17 @@ class WZI_Sync_Customers {
         $mapping_table = $wpdb->prefix . 'wzi_field_mapping'; // Unificado a singular
         
         $mappings = $wpdb->get_results($wpdb->prepare(
-            "SELECT * FROM {$mapping_table} 
-             WHERE entity_type = %s AND is_active = 1",
+            // Seleccionar explícitamente las columnas con los nombres correctos por claridad y eficiencia
+            "SELECT wc_field, zoho_field, direction, transform_function FROM {$mapping_table}
+             WHERE module = %s AND is_active = 1", // entity_type -> module
             'customer'
         ));
         
         foreach ($mappings as $mapping) {
-            $this->field_mapping[$mapping->woo_field] = array(
+            // Usar los nombres de columna correctos del objeto $mapping
+            $this->field_mapping[$mapping->wc_field] = array(
                 'zoho_field' => $mapping->zoho_field,
-                'sync_direction' => $mapping->sync_direction,
+                'sync_direction' => $mapping->direction, // sync_direction -> direction
                 'transform_function' => $mapping->transform_function,
             );
         }

--- a/includes/sync/class-wzi-sync-products.php
+++ b/includes/sync/class-wzi-sync-products.php
@@ -121,15 +121,17 @@ class WZI_Sync_Products {
         $mapping_table = $wpdb->prefix . 'wzi_field_mapping';
         
         $mappings = $wpdb->get_results($wpdb->prepare(
-            "SELECT * FROM {$mapping_table} 
-             WHERE entity_type = %s AND is_active = 1",
+            // Seleccionar explícitamente las columnas con los nombres correctos por claridad y eficiencia
+            "SELECT wc_field, zoho_field, direction, transform_function FROM {$mapping_table}
+             WHERE module = %s AND is_active = 1", // entity_type -> module
             'product'
         ));
         
         foreach ($mappings as $mapping) {
-            $this->field_mapping[$mapping->woo_field] = array(
+            // Usar los nombres de columna correctos del objeto $mapping
+            $this->field_mapping[$mapping->wc_field] = array(
                 'zoho_field' => $mapping->zoho_field,
-                'sync_direction' => $mapping->sync_direction,
+                'sync_direction' => $mapping->direction, // sync_direction -> direction
                 'transform_function' => $mapping->transform_function,
             );
         }


### PR DESCRIPTION
- Corrected load_field_mapping in WZI_Sync_Products and WZI_Sync_Customers to use correct column names (wc_field, direction, module).
- Changed textdomain loading in WZI_Main to use the 'init' hook to prevent 'triggered too early' notices.