### PR TITLE
Refactor: Suppress notices in test_api_connection AJAX handler

### DIFF
--- a/includes/class-wzi-admin.php
+++ b/includes/class-wzi-admin.php
@@ -391,7 +391,15 @@ class WZI_Admin {
      *
      * @since    1.0.0
      */
-    public function ajax_test_api_connection() { // Nombre actualizado para coincidir
+    public function ajax_test_api_connection() {
+        // Intentar suprimir notices para asegurar una respuesta JSON limpia
+        // Esto es un parche para el notice _load_textdomain_just_in_time que corrompe el JSON.
+        $original_display_errors = ini_get('display_errors');
+        $original_error_reporting = error_reporting();
+
+        @ini_set('display_errors', 0);
+        error_reporting($original_error_reporting & ~E_NOTICE & ~E_USER_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED & ~E_WARNING & ~E_USER_WARNING); // Suprimir notices y warnings
+
         check_ajax_referer('wzi_admin_nonce', 'nonce');
 
         if (!current_user_can('manage_wzi_settings')) { // Ajustar capacidad si es necesario


### PR DESCRIPTION
- Modified WZI_Admin::ajax_test_api_connection() to set error_reporting and ini_set('display_errors', 0) at the beginning of the function.
- This is an attempt to prevent PHP notices (specifically '_load_textdomain_just_in_time') from corrupting the JSON response and causing client-side parsing errors.