### PR TITLE
Refactor: Simplify textdomain loading in WZI_i18n

### DIFF
--- a/includes/class-wzi-i18n.php
+++ b/includes/class-wzi-i18n.php
@@ -28,10 +28,9 @@ class WZI_i18n {
      * @since    1.0.0
      */
     public function load_plugin_textdomain() {
-        load_plugin_textdomain(
-            'woocommerce-zoho-integration',
-            false,
-            dirname(dirname(plugin_basename(__FILE__))) . '/languages/'
-        );
+        // WordPress debería usar el 'Domain Path' especificado en la cabecera del plugin
+        // cuando el tercer argumento (deprecado para path absoluto) es false o se omite.
+        // El 'Text Domain' y 'Domain Path' están definidos en woocommerce-zoho-integration.php
+        load_plugin_textdomain('woocommerce-zoho-integration');
     }
 }


### PR DESCRIPTION
- Simplified the call to load_plugin_textdomain in WZI_i18n::load_plugin_textdomain to rely on the 'Text Domain' and 'Domain Path' headers in the main plugin file.
- This adheres to standard WordPress practice for textdomain loading when hooked to 'init'.