### PR TITLE
Fix: Correct PHP parse error in class-wzi-sync-customers.php

### DIFF
--- a/includes/sync/class-wzi-sync-customers.php
+++ b/includes/sync/class-wzi-sync-customers.php
@@ -680,8 +680,7 @@ class WZI_Sync_Customers {
         // $this->logger->info(sprintf('Successfully synced WC User ID: %d to Zoho Contact ID: %s', $customer_id, $processed_record['id']));
         error_log("WZI_Sync_Customers: User ID $customer_id - SINCRONIZACIÓN EXITOSA a Zoho Contact ID: " . $processed_record['id']);
         return $processed_record;
-        }
-    }
+    } // Cierre correcto del método sync_customer_to_zoho
 
     /**
      * Sincronizar contacto a WooCommerce.


### PR DESCRIPTION
- Removed an extraneous closing curly brace at the end of the sync_customer_to_zoho method that was causing a T_PRIVATE parse error.