### PR TITLE
Debug: Force error display and minimize activation logic

### DIFF
--- a/includes/class-wzi-activator.php
+++ b/includes/class-wzi-activator.php
@@ -27,48 +27,52 @@ class WZI_Activator {
      * @since    1.0.0
      */
     public static function activate() {
-        error_log("WZI_Activator: activate() INICIO");
-        // Crear tablas de base de datos
-        self::create_database_tables();
-        error_log("WZI_Activator: DESPUÉS de create_database_tables()");
+        // Forzar visualización de errores y logging máximo para la activación
+        $original_display_errors = @ini_set('display_errors', 1);
+        $original_error_reporting = @error_reporting(E_ALL);
+        error_log("WZI_Activator: activate() INICIO. display_errors y error_reporting forzados para depuración.");
+
+        // self::create_database_tables(); // Comentado inicialmente
+        // error_log("WZI_Activator: DESPUÉS de create_database_tables()");
         
-        // Establecer configuraciones por defecto
         // self::set_default_settings();
         // error_log("WZI_Activator: DESPUÉS de set_default_settings()");
         
-        // Crear roles y capacidades
         // self::create_roles_and_capabilities();
         // error_log("WZI_Activator: DESPUÉS de create_roles_and_capabilities()");
         
-        // Programar tareas cron
         // self::schedule_cron_jobs();
         // error_log("WZI_Activator: DESPUÉS de schedule_cron_jobs()");
         
-        // Crear carpetas necesarias
         // self::create_plugin_folders();
         // error_log("WZI_Activator: DESPUÉS de create_plugin_folders()");
         
-        // Limpiar caché
         // flush_rewrite_rules();
         // error_log("WZI_Activator: DESPUÉS de flush_rewrite_rules()");
-        error_log("WZI_Activator: activate() FIN - SOLO TABLAS ACTIVAS");
+        error_log("WZI_Activator: activate() FIN - TODO COMENTADO INICIALMENTE EXCEPTO LOGS.");
+
+        // Restaurar configuración original de errores
+        if ($original_display_errors !== false) {
+            @ini_set('display_errors', $original_display_errors);
+        }
+        if ($original_error_reporting !== false) {
+            @error_reporting($original_error_reporting);
+        }
     }
 
     /**
      * Crear tablas de base de datos
      */
     private static function create_database_tables() {
-        error_log("WZI_Activator: create_database_tables() INICIO");
+        error_log("WZI_Activator: create_database_tables() INICIO - TODO COMENTADO INTERNAMENTE");
 
         // Incluir los archivos de migración
-        require_once WZI_PLUGIN_DIR . 'database/migrations/create_sync_logs_table.php';
-        require_once WZI_PLUGIN_DIR . 'database/migrations/create_sync_queue_table.php';
-        require_once WZI_PLUGIN_DIR . 'database/migrations/create_mapping_table.php';
-        require_once WZI_PLUGIN_DIR . 'database/migrations/create_auth_tokens_table.php';
+        // require_once WZI_PLUGIN_DIR . 'database/migrations/create_sync_logs_table.php';
+        // require_once WZI_PLUGIN_DIR . 'database/migrations/create_sync_queue_table.php';
+        // require_once WZI_PLUGIN_DIR . 'database/migrations/create_mapping_table.php';
+        // require_once WZI_PLUGIN_DIR . 'database/migrations/create_auth_tokens_table.php';
 
-        // Ejecutar SOLO UNA a la vez para probar, comenzando con la que más hemos modificado.
-        // Comenta/descomenta para aislar.
-
+        // Comentar todas las llamadas para la prueba inicial
         // error_log("WZI_Activator: ANTES de wzi_create_sync_logs_table()");
         // wzi_create_sync_logs_table();
         // error_log("WZI_Activator: DESPUÉS de wzi_create_sync_logs_table()");
@@ -77,16 +81,16 @@ class WZI_Activator {
         // wzi_create_sync_queue_table();
         // error_log("WZI_Activator: DESPUÉS de wzi_create_sync_queue_table()");
 
-        error_log("WZI_Activator: ANTES de wzi_create_mapping_table()");
-        wzi_create_mapping_table(); // <--- SOLO ESTA ACTIVA INICIALMENTE
-        error_log("WZI_Activator: DESPUÉS de wzi_create_mapping_table()");
+        // error_log("WZI_Activator: ANTES de wzi_create_mapping_table()");
+        // wzi_create_mapping_table();
+        // error_log("WZI_Activator: DESPUÉS de wzi_create_mapping_table()");
 
         // error_log("WZI_Activator: ANTES de wzi_create_auth_tokens_table()");
         // wzi_create_auth_tokens_table();
         // error_log("WZI_Activator: DESPUÉS de wzi_create_auth_tokens_table()");
 
-        update_option('wzi_db_schema_version', WZI_VERSION);
-        error_log("WZI_Activator: create_database_tables() FIN. Opción wzi_db_schema_version actualizada a " . WZI_VERSION);
+        // update_option('wzi_db_schema_version', WZI_VERSION);
+        // error_log("WZI_Activator: create_database_tables() FIN. Opción wzi_db_schema_version actualizada a " . WZI_VERSION);
     }
     
     /**

--- a/woocommerce-zoho-integration.php
+++ b/woocommerce-zoho-integration.php
@@ -18,6 +18,10 @@ if (!defined('WPINC')) {
     die;
 }
 
+// Intento temporal de forzar la visualización de errores durante la carga inicial del plugin
+@ini_set('display_errors', 1);
+@error_reporting(E_ALL);
+
 /**
  * Versión actual del plugin.
  */


### PR DESCRIPTION
- Added @ini_set('display_errors', 1) and @error_reporting(E_ALL) temporarily at the beginning of woocommerce-zoho-integration.php and WZI_Activator::activate() to try and force PHP errors to display during activation if they are the source of 'unexpected output'.
- Commented out all functional calls within WZI_Activator::activate() and WZI_Activator::create_database_tables() to create a minimal activation process for isolating the 'unexpected output' error source.